### PR TITLE
Include unistd.h in util.h, which is required to use close(2).

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -34,6 +34,7 @@ typedef unsigned char uint8_t;
 #else
 #include <sys/mman.h>
 #include <fcntl.h>
+#include <unistd.h>
 #endif
 
 #ifdef _LP64


### PR DESCRIPTION
hello!

I'm using ubuntu 12.10, which include g++ 4.7.2. In my environment, unistd.h is required to call close(2).

In this pull request, I modified util.h to include unistd.h if _MSC_VER is not defined.
